### PR TITLE
#feat:#217 Make A3D the default choice in the task generation form

### DIFF
--- a/label_studio/taskgeneration/views.py
+++ b/label_studio/taskgeneration/views.py
@@ -226,6 +226,7 @@ def generate_taskgen_form(request, project_id):
                     columns_names_choices = []
                     for i, column_name in enumerate(column_names):
                         columns_names_choices.append((i, column_name))
+                    columns_names_choices.reverse()
                     # Pass the choices to the session, this way it can more easily be retrieved later in the flow.
                     request.session['choices'] = columns_names_choices
                     return redirect('taskgeneration:taskgeneration_form', project_id=project_id)


### PR DESCRIPTION
Simply done by flipping the choices list. A3D was always the last one since we add that one ourselves